### PR TITLE
Update ERI duration range in trial configuration for optimization

### DIFF
--- a/backend/services/insure_smart_optimizer.py
+++ b/backend/services/insure_smart_optimizer.py
@@ -596,7 +596,7 @@ def generate_trial_configuration(
                 continue
             elif peril_type == "ERI":
                 trigger = trial.suggest_int(f"eri_trigger_{period_idx}_{peril_idx}", 40, 200)
-                dur_min, dur_max = get_constrained_duration_range(1, 5, period_length)
+                dur_min, dur_max = get_constrained_duration_range(3, 5, period_length)
                 duration = trial.suggest_int(f"eri_duration_{period_idx}_{peril_idx}", dur_min, dur_max)
                 # Use discrete values for unit_payout to ensure 2 decimal places
                 unit_payout_options = [round(x * 0.05, 2) for x in range(10, 61)]  # 0.50 to 3.00 in 0.05 steps

--- a/frontend/components/operations-dashboard/OperationsSidebar.tsx
+++ b/frontend/components/operations-dashboard/OperationsSidebar.tsx
@@ -124,7 +124,7 @@ export function OperationsSidebar({ user }: OperationsSidebarProps) {
       {/* Footer */}
       <div className="p-4 border-t border-gray-200">
         <div className="text-xs text-gray-500 text-center">
-          AccuRate v1.0
+          AccuRate v3.2
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Adjusted the minimum duration range for the ERI trigger in the `generate_trial_configuration` function from 1 to 3, enhancing the configuration options for the optimization process.